### PR TITLE
Ignore IntelliJ *.iml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ build/
 /.idea
 modules.xml
 *.ipr
+*.iml
 
 
 ### System Files ###


### PR DESCRIPTION
Add *.iml to .gitignore to ignore all IntelliJ modules info files.